### PR TITLE
feat(passport-sdk-types): add Brightid and Github providers to types

### DIFF
--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -119,4 +119,4 @@ export type Passport = {
 export type DID = string;
 
 // Currently set-up Providers
-export type PROVIDER_ID = "Google" | "Ens" | "Poh" | "Twitter" | "POAP" | "Facebook";
+export type PROVIDER_ID = "Google" | "Ens" | "Poh" | "Twitter" | "POAP" | "Facebook" | "Brightid" | "Github";


### PR DESCRIPTION
feat(passport-sdk-types): add Brightid and Github providers to types

[fix #9]