### PR TITLE
fix(passport-sdk-types): update types to match passport repo types

### DIFF
--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -104,6 +104,9 @@ export type VerifiableCredentialRecord = {
 };
 
 export type Stamp = {
+  // recordUserName: string;
+  // credentialIssuer: string;
+  streamId?: string; // Must not be undefined for stamps loaded from ceramic
   provider: PROVIDER_ID;
   credential: VerifiableCredential;
   verified?: boolean;
@@ -119,4 +122,14 @@ export type Passport = {
 export type DID = string;
 
 // Currently set-up Providers
-export type PROVIDER_ID = "Google" | "Ens" | "Poh" | "Twitter" | "POAP" | "Facebook" | "Brightid" | "Github";
+export type PROVIDER_ID =
+  | "Google"
+  | "Ens"
+  | "Poh"
+  | "Twitter"
+  | "POAP"
+  | "Facebook"
+  | "Brightid"
+  | "Github"
+  | "Linkedin"
+  | "Discord";


### PR DESCRIPTION
- Keeping the verified type on the Stamp will make the verifier sdk adaptable. The verified option is also set to optional. This way the type is only populated after the verified sdk is used.

Closes #325