### PR TITLE
docs: Clarity improvement on reader usage

### DIFF
--- a/packages/reader/README.md
+++ b/packages/reader/README.md
@@ -30,7 +30,7 @@ Firstly, we need to import the library/bundle and construct a `PassportReader` i
 
 ```js
 // add to your project as a module
-import PassportReader from "@gitcoinco/passport-sdk-reader"
+import { PassportReader } from "@gitcoinco/passport-sdk-reader"
 
 // or import the bundle
 <script src="./dist/reader.bundle.js" type="script/javascript"/>


### PR DESCRIPTION
PassportReader doesn't have a default export, so you need to either just import { PassportReader } or do something like reader.PassportReader

I updated the README to use the former. As written in the README currently, a user could get the following error: `TypeError: PassportReader is not a constructor`